### PR TITLE
Fix incorrect min version for vscode

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/Microsoft/pyright"
     },
     "engines": {
-        "vscode": "^1.86.0"
+        "vscode": "^1.89.0"
     },
     "keywords": [
         "python"


### PR DESCRIPTION
Fix for github.com/microsoft/pyright/issues/8344

Describe the bug
Pyright v1.370+ has the engine version in package.json set to 1.86, however when starting pyright on 1.86 the following error is thrown in the console:

The language client requires VS Code version ^1.89.0 but received version 1.86.<>
Code or Screenshots
This is happening because the languageserver node package pyright depends on has a min engine version of 1.89
https://github.com/microsoft/vscode-languageserver-node/blob/release/client/10.0.0-next.6/client/package.json